### PR TITLE
Fix variable name typo

### DIFF
--- a/opencl_ruby_ffi/lib/opencl_ruby_ffi/CommandQueue.rb
+++ b/opencl_ruby_ffi/lib/opencl_ruby_ffi/CommandQueue.rb
@@ -566,7 +566,7 @@ module OpenCL
     objs = nil
     if num_objs > 0 then
       objs = MemoryPointer::new(  Mem, num_objs )
-      [mem_objects].flatten.each_with_index { |o, i|
+      [mem_objects].flatten.each_with_index { |e, i|
         objs[i].write_pointer(e)
       }
     end
@@ -600,7 +600,7 @@ module OpenCL
     objs = nil
     if num_objs > 0 then
       objs = MemoryPointer::new( Mem, num_objs )
-      [mem_objects].flatten.each_with_index { |o, i|
+      [mem_objects].flatten.each_with_index { |e, i|
         objs[i].write_pointer(e)
       }
     end


### PR DESCRIPTION
The variable name was wrong in both of these functions, causing an error :

`block in enqueue_acquire_gl_objects': undefined local variable or method `e' for OpenCL:Module (NameError)`